### PR TITLE
watch対象のeventを制限した

### DIFF
--- a/lib/define.js
+++ b/lib/define.js
@@ -5,6 +5,7 @@
  * @param {function} handler - Change handler function
  * @param {Object} [options={}] - Optional settings
  * @param {number} [options.delay=100] - Delay to trigger watch
+ * @param {string} [options.events=["change"]] - Target events
  * @returns {function} Defined task
  */
 'use strict'
@@ -12,12 +13,12 @@
 const co = require('co')
 const asleep = require('asleep')
 const path = require('path')
-const minimatch = require('minimatch')
 
 /** @lends define */
 function define (filenames, handler, options = {}) {
   let {
-    delay = 100
+    delay = 100,
+    events = [ 'change' ]
   } = options
 
   function task (ctx) {
@@ -26,8 +27,8 @@ function define (filenames, handler, options = {}) {
       let timers = []
       let watching = true
       let close = yield watcher.watch(filenames, (event, filename) => {
-        let gone = !minimatch(filename, filenames, { cwd })
-        if (gone) {
+        let hit = !!~[].concat(events).indexOf(event)
+        if (!hit) {
           return
         }
         logger.trace(`File changed:`, path.relative(cwd, filename))

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Pon task to watch files
  * @module pon-task-watch
- * @version 1.0.0
+ * @version 1.0.1
  */
 
 'use strict'


### PR DESCRIPTION
IDEが裏でバックアップ取るたびに誤爆していた