### PR TITLE
watch時にrequire.cacheを明示的に消すようにした

### DIFF
--- a/lib/define.js
+++ b/lib/define.js
@@ -38,6 +38,12 @@ function define (filenames, handler, options = {}) {
         clearTimeout(timers[ event ])
         timers[ event ] = setTimeout(() => {
           logger.trace(`File changed:`, path.relative(cwd, filename))
+          let cacheKeys = Object.keys(require.cache).filter((cacheKey) => cacheKey.match(filename))
+          for (let cacheKey of cacheKeys) {
+            delete require.cache[ cacheKey ]
+            logger.trace(`Require cache deleted:`, path.relative(cwd, filename))
+          }
+
           handling = true
           Promise.resolve(handler(event, filename))
             .catch((err) => logger.error(err))
@@ -52,6 +58,7 @@ function define (filenames, handler, options = {}) {
         watching = false
         close()
       })
+      yield asleep(0)
       while (watching) {
         yield asleep(10)
       }

--- a/test/define_test.js
+++ b/test/define_test.js
@@ -7,6 +7,7 @@
 const define = require('../lib/define.js')
 const ponContext = require('pon-context')
 const { ok } = require('assert')
+const path = require('path')
 const asleep = require('asleep')
 const writeout = require('writeout')
 
@@ -28,6 +29,7 @@ describe('define', function () {
     let srcDir = `${__dirname}/../tmp/testing-watching/src`
     let destDir = `${__dirname}/../tmp/testing-watching/dest`
     let src = srcDir + '/foo.pcss'
+    require.cache[ path.resolve(srcDir, src) ] = { m: 'This is mock cache' }
     yield writeout(src, ':root { --red: #d33; } a { &:hover { color: color(var(--red) a(54%)); } }', { mkdirp: true })
     yield asleep(100)
     define(srcDir + '/*.*', (event, filename) => {


### PR DESCRIPTION
npm5だとpcssのwatchがなにやらうまく動かなかったので。明示的にcacheを消す処理を入れた